### PR TITLE
Update package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
     "handlebars": "^4.7.6",
     "isarray": "^2.0.5",
     "mkdirp": "^1.0.4",
-    "mobx": "^4.2.0",
+    "mobx": "^6.0.0",
     "node-libs-browser": "^2.2.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Update mobx to version 6 since mobx-react-lite 3 (which is not pinned) requires version 6